### PR TITLE
docs: Fix source code URL in workflow metadata

### DIFF
--- a/wf/__init__.py
+++ b/wf/__init__.py
@@ -871,7 +871,7 @@ def rnaseq(
             name: LatchBio
             email:
             github:
-        repository: github.com/latchbio/rnaseq
+        repository: github.com/latch-verified/bulk-rnaseq
         license:
             id: MIT
         flow:


### PR DESCRIPTION
Was testing out the workflow and noticed the Source Code URL in the interface links to a 404. This fixes it.